### PR TITLE
Allow Compute Nodes to reap processes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.5"
+version: "3.8"
 
 services:
   base:
@@ -61,6 +61,7 @@ services:
       - slurmdbd
 
   cpn01:
+    init: true
     image: ubccr/hpcts:slurm-${HPCTS_VERSION}
     command: ["slurmd"]
     hostname: cpn01
@@ -78,6 +79,7 @@ services:
       - slurmctld
 
   cpn02:
+    init: true
     image: ubccr/hpcts:slurm-${HPCTS_VERSION}
     command: ["slurmd"]
     hostname: cpn02


### PR DESCRIPTION
ref: https://docs.docker.com/compose/compose-file/#init

ran 14 jobs
before:

```
[hpcadmin@frontend ~]$ ssh cpn02 'ps aux --forest' ; ssh cpn01 'ps aux --forest'
Warning: Permanently added 'cpn02,172.27.0.8' (ECDSA) to the list of known hosts.
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.2 146476  6000 ?        Ss   20:25   0:01 /usr/sbin/slurmd -Dvvv
munge       13  0.0  0.1 221676  2560 ?        Sl   20:25   0:00 /usr/sbin/munged
root        20  0.0  0.1 112936  2920 ?        Ss   20:25   0:00 /usr/sbin/sshd
root       174  0.0  0.4 150620  8884 ?        Ss   21:55   0:00  \_ sshd: hpcadmin [priv]
hpcadmin   176  0.0  0.2 150620  4220 ?        S    21:55   0:00      \_ sshd: hpcadmin@notty
hpcadmin   177  0.0  0.1  55200  3980 ?        Rs   21:55   0:00          \_ ps aux --forest
root        52  0.0  0.0      0     0 ?        Z    21:52   0:00 [slurmstepd] <defunct>
root        63  0.0  0.0      0     0 ?        Z    21:52   0:00 [slurmstepd] <defunct>
root        74  0.0  0.0      0     0 ?        Z    21:53   0:00 [slurmstepd] <defunct>
hpcadmin    82  0.0  0.0      0     0 ?        Z    21:53   0:00 [sshd] <defunct>
root       107  0.0  0.0      0     0 ?        Z    21:53   0:00 [slurmstepd] <defunct>
root       120  0.0  0.0      0     0 ?        Z    21:53   0:00 [slurmstepd] <defunct>
root       131  0.0  0.0      0     0 ?        Z    21:54   0:00 [slurmstepd] <defunct>
root       142  0.0  0.0      0     0 ?        Z    21:54   0:00 [slurmstepd] <defunct>
hpcadmin   150  0.0  0.0      0     0 ?        Z    21:54   0:00 [sshd] <defunct>
hpcadmin   164  0.0  0.0      0     0 ?        Z    21:54   0:00 [sshd] <defunct>
Warning: Permanently added 'cpn01,172.27.0.6' (ECDSA) to the list of known hosts.
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.2 146476  5932 ?        Ss   20:25   0:01 /usr/sbin/slurmd -Dvvv
munge       12  0.0  0.1 221676  2516 ?        Sl   20:25   0:00 /usr/sbin/munged
root        19  0.0  0.1 112936  2912 ?        Ss   20:25   0:00 /usr/sbin/sshd
root       175  0.0  0.4 150620  8848 ?        Ss   21:55   0:00  \_ sshd: hpcadmin [priv]
hpcadmin   177  0.0  0.2 150620  4164 ?        S    21:55   0:00      \_ sshd: hpcadmin@notty
hpcadmin   178  0.0  0.1  55200  3956 ?        Rs   21:55   0:00          \_ ps aux --forest
root        51  0.0  0.0      0     0 ?        Z    21:52   0:00 [slurmstepd] <defunct>
root        62  0.0  0.0      0     0 ?        Z    21:52   0:00 [slurmstepd] <defunct>
hpcadmin    70  0.0  0.0      0     0 ?        Z    21:53   0:00 [sshd] <defunct>
root        95  0.0  0.0      0     0 ?        Z    21:53   0:00 [slurmstepd] <defunct>
root       110  0.0  0.0      0     0 ?        Z    21:53   0:00 [slurmstepd] <defunct>
root       121  0.0  0.0      0     0 ?        Z    21:53   0:00 [slurmstepd] <defunct>
root       132  0.0  0.0      0     0 ?        Z    21:54   0:00 [slurmstepd] <defunct>
root       143  0.0  0.0      0     0 ?        Z    21:54   0:00 [slurmstepd] <defunct>
hpcadmin   151  0.0  0.0      0     0 ?        Z    21:54   0:00 [sshd] <defunct>
hpcadmin   165  0.0  0.0      0     0 ?        Z    21:54   0:00 [sshd] <defunct>
[hpcadmin@frontend ~]$
```

after:

```
[hpcadmin@frontend ~]$  ssh cpn02 'ps aux --forest' ; ssh cpn01 'ps aux --forest'
Warning: Permanently added 'cpn02,172.27.0.7' (ECDSA) to the list of known hosts.
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0    996     4 ?        Ss   23:10   0:00 /sbin/docker-init -- /usr/local/bin/entrypoint.sh slurmd
root         6  0.1  0.2 146476  5832 ?        S    23:10   0:00 /usr/sbin/slurmd -Dvvv
munge       13  0.0  0.1 221676  2568 ?        Sl   23:10   0:00 /usr/sbin/munged
root        20  0.0  0.1 112936  2920 ?        Ss   23:11   0:00 /usr/sbin/sshd
root       160  1.0  0.4 150620  8960 ?        Ss   23:18   0:00  \_ sshd: hpcadmin [priv]
hpcadmin   162  0.0  0.2 150620  4448 ?        S    23:18   0:00      \_ sshd: hpcadmin@notty
hpcadmin   163  0.0  0.1  55200  3968 ?        Rs   23:18   0:00          \_ ps aux --forest
Warning: Permanently added 'cpn01,172.27.0.8' (ECDSA) to the list of known hosts.
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0    996     4 ?        Ss   23:10   0:00 /sbin/docker-init -- /usr/local/bin/entrypoint.sh slurmd
root         6  0.1  0.2 146476  5832 ?        S    23:10   0:00 /usr/sbin/slurmd -Dvvv
munge       13  0.0  0.1 221676  2408 ?        Sl   23:10   0:00 /usr/sbin/munged
root        20  0.0  0.1 112936  2872 ?        Ss   23:11   0:00 /usr/sbin/sshd
root       158  0.0  0.4 150620  8896 ?        Ss   23:18   0:00  \_ sshd: hpcadmin [priv]
hpcadmin   160  0.0  0.2 150620  4328 ?        S    23:18   0:00      \_ sshd: hpcadmin@notty
hpcadmin   161  0.0  0.1  55200  3948 ?        Rs   23:18   0:00          \_ ps aux --forest
[hpcadmin@frontend ~]$
```