### PR TITLE
Use LDAP for users

### DIFF
--- a/base/install.sh
+++ b/base/install.sh
@@ -113,7 +113,7 @@ do
     cat > /home/$uid/.ssh/config <<EOF
 Host *
    StrictHostKeyChecking no
-   UserKnownHostsFile=/dev/null
+   UserKnownHostsFile /dev/null
 EOF
     chmod 0600 /home/$uid/.ssh/config
     cp /etc/skel/.bash* /home/$uid

--- a/base/install.sh
+++ b/base/install.sh
@@ -12,6 +12,16 @@ source /build/base.config
 GOSU_VERSION=${GOSU_VERSION:-1.12}
 
 #------------------------
+# Setup system user/groups
+#------------------------
+log_info "Creating munge user account.."
+groupadd -r munge
+useradd -r -g munge -s /sbin/nologin -d /var/run/munge munge
+log_info "Creating sssd user account.."
+groupadd -r sssd
+useradd -r -g sssd -d / -s /sbin/nologin sssd
+
+#------------------------
 # Install base packages
 #------------------------
 log_info "Installing base packages.."
@@ -79,7 +89,7 @@ EOF
 # Setup user accounts
 #------------------------
 
-idnumber=1000
+idnumber=1001
 for uid in hpcadmin $USERS
 do
     log_info "Bootstrapping $uid user account.."

--- a/base/install.sh
+++ b/base/install.sh
@@ -116,6 +116,8 @@ Host *
 EOF
     chown -R $idnumber:$idnumber /home/$uid/.ssh
     chmod 0600 /home/$uid/.ssh/config
+    cp /etc/skel/.bash* /home/$uid
+    chown $idnumber:$idnumber /home/$uid/.bash*
     idnumber=$((idnumber + 1))
 done
 

--- a/base/install.sh
+++ b/base/install.sh
@@ -106,6 +106,7 @@ idnumber=1001
 for uid in hpcadmin $USERS
 do
     log_info "Bootstrapping $uid user account.."
+    install -d -o $idnumber -g $idnumber -m 0700 /home/$uid
     install -d -o $idnumber -g $idnumber -m 0700 /home/$uid/.ssh
     ssh-keygen -b 2048 -t rsa -f /home/$uid/.ssh/id_rsa -q -N ""
     install -o $idnumber -g $idnumber -m 0600 /home/$uid/.ssh/id_rsa.pub /home/$uid/.ssh/authorized_keys
@@ -117,7 +118,7 @@ EOF
     chown -R $idnumber:$idnumber /home/$uid/.ssh
     chmod 0600 /home/$uid/.ssh/config
     cp /etc/skel/.bash* /home/$uid
-    chown $idnumber:$idnumber /home/$uid/.bash*
+    chown $idnumber:$idnumber /home/$uid
     idnumber=$((idnumber + 1))
 done
 

--- a/base/install.sh
+++ b/base/install.sh
@@ -61,28 +61,41 @@ authconfig --enableldap \
   --nostart \
   --update
 
+cat > /etc/openldap/ldap.conf <<EOF
+TLS_CACERTDIR /etc/openldap/cacerts
+TLS_REQCERT never
+SASL_NOCANON	on
+URI ldaps://ldap:636
+BASE dc=example,dc=org
+EOF
+
 cat > /etc/sssd/sssd.conf <<EOF
 [domain/default]
+debug_level = 3
 autofs_provider = ldap
 ldap_schema = rfc2307bis
+ldap_group_member = member
 ldap_search_base = dc=example,dc=org
 id_provider = ldap
 auth_provider = ldap
 chpass_provider = ldap
-ldap_uri = ldap://ldap:389
+ldap_uri = ldaps://ldap:636
 cache_credentials = True
-ldap_tls_cacertdir = /etc/openldap/cacerts
+ldap_tls_reqcert = never
 ldap_default_bind_dn = cn=admin,dc=example,dc=org
 ldap_default_authtok = admin
 
 [sssd]
+debug_level = 3
 services = nss, pam
 domains = default
 
 [nss]
+debug_level = 3
 homedir_substring = /home
 
 [pam]
+debug_level = 3
 EOF
 
 #------------------------

--- a/base/install.sh
+++ b/base/install.sh
@@ -115,10 +115,9 @@ Host *
    StrictHostKeyChecking no
    UserKnownHostsFile=/dev/null
 EOF
-    chown -R $idnumber:$idnumber /home/$uid/.ssh
     chmod 0600 /home/$uid/.ssh/config
     cp /etc/skel/.bash* /home/$uid
-    chown $idnumber:$idnumber /home/$uid
+    chown -R $idnumber:$idnumber /home/$uid
     idnumber=$((idnumber + 1))
 done
 

--- a/coldfront/entrypoint.sh
+++ b/coldfront/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 if [ "$1" = "serve" ]
 then
     echo "---> Starting SSSD on coldfront ..."
-    /sbin/sssd
+    /sbin/sssd --logger=stderr -d 3 -i 2>&1 &
 
     echo "---> Starting the MUNGE Authentication service (munged) on coldfront ..."
     gosu munge /usr/sbin/munged
@@ -30,7 +30,7 @@ then
     fi
 
     echo "---> Starting sshd on coldfront..."
-    /usr/sbin/sshd
+    /usr/sbin/sshd -e
 
     echo "---> Starting nginx on coldfront..."
     /sbin/nginx

--- a/coldfront/entrypoint.sh
+++ b/coldfront/entrypoint.sh
@@ -3,6 +3,9 @@ set -e
 
 if [ "$1" = "serve" ]
 then
+    echo "---> Starting SSSD on coldfront ..."
+    /sbin/sssd
+
     echo "---> Starting the MUNGE Authentication service (munged) on coldfront ..."
     gosu munge /usr/sbin/munged
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     image: ubccr/hpcts:base-${HPCTS_VERSION}
     build:
       context: ./base
+    networks:
+      - compute
     depends_on:
       - ldap
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     environment:
       - CONTAINER_LOG_LEVEL=debug
       - LDAP_RFC2307BIS_SCHEMA=true
-      - LDAP_TLS=false
       - LDAP_REMOVE_CONFIG_AFTER_SETUP=false
+      - LDAP_TLS_VERIFY_CLIENT=never
     networks:
       - compute
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,26 @@
 version: "3.8"
 
 services:
+  ldap:
+    image: ubccr/hpcts:ldap-${HPCTS_VERSION}
+    build:
+      context: ./ldap
+    hostname: ldap
+    container_name: ldap
+    environment:
+      - CONTAINER_LOG_LEVEL=debug
+      - LDAP_RFC2307BIS_SCHEMA=true
+      - LDAP_TLS=false
+      - LDAP_REMOVE_CONFIG_AFTER_SETUP=false
+    networks:
+      - compute
+
   base:
     image: ubccr/hpcts:base-${HPCTS_VERSION}
     build:
       context: ./base
+    depends_on:
+      - ldap
 
   mysql:
     image: mariadb:$MARIADB_VERSION
@@ -41,6 +57,7 @@ services:
       - "6819"
     depends_on:
       - base
+      - ldap
       - mysql
 
   slurmctld:
@@ -58,6 +75,7 @@ services:
       - "22"
       - "6817"
     depends_on:
+      - ldap
       - slurmdbd
 
   cpn01:
@@ -76,6 +94,7 @@ services:
       - "22"
       - "6818"
     depends_on:
+      - ldap
       - slurmctld
 
   cpn02:
@@ -94,6 +113,7 @@ services:
       - "22"
       - "6818"
     depends_on:
+      - ldap
       - slurmctld
 
   frontend:
@@ -110,6 +130,7 @@ services:
     ports:
       - "127.0.0.1:6222:22"
     depends_on:
+      - ldap
       - slurmctld
 
   coldfront:
@@ -133,6 +154,7 @@ services:
     ports:
       - "127.0.0.1:2443:443"
     depends_on:
+      - ldap
       - mysql
       - frontend
 
@@ -156,6 +178,7 @@ services:
     ports:
       - "127.0.0.1:3443:443"
     depends_on:
+      - ldap
       - frontend
 
   xdmod:
@@ -178,6 +201,7 @@ services:
     ports:
       - "127.0.0.1:4443:443"
     depends_on:
+      - ldap
       - mysql
       - frontend
 

--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -1,0 +1,3 @@
+FROM osixia/openldap:1.4.0
+COPY . /build
+RUN /build/install.sh && rm -rf /build

--- a/ldap/base.config
+++ b/ldap/base.config
@@ -1,0 +1,3 @@
+GOSU_VERSION=1.12
+USERS="cgray sfoster csimmons astewart"
+PASSWD_cgray="test123"

--- a/ldap/install.sh
+++ b/ldap/install.sh
@@ -27,7 +27,7 @@ EOF
 # Setup user accounts
 #------------------------
 
-idnumber=1000
+idnumber=1001
 for uid in hpcadmin $USERS
 do
     log_info "Adding LDIF for $uid user account with uidnumber $idnumber.."

--- a/ldap/install.sh
+++ b/ldap/install.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+
+log_info() {
+  printf "\n\e[0;35m $1\e[0m\n\n"
+}
+
+source /build/base.config
+
+#------------------------
+# Bootstrap LDAP OUs
+#------------------------
+mkdir -p /container/service/slapd/assets/config/bootstrap/ldif/custom
+cat > /container/service/slapd/assets/config/bootstrap/ldif/custom/0-ous.ldif <<EOF
+dn: ou=People,dc=example,dc=org
+objectClass: organizationalUnit
+ou: People
+
+dn: ou=Groups,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Groups
+EOF
+
+#------------------------
+# Setup user accounts
+#------------------------
+
+idnumber=1000
+for uid in hpcadmin $USERS
+do
+    log_info "Adding LDIF for $uid user account with uidnumber $idnumber.."
+    passvar="PASSWD_$uid"
+    passwd=${!passvar:-ilovelinux}
+    cat > /container/service/slapd/assets/config/bootstrap/ldif/custom/1-$uid.ldif <<EOF
+dn: cn=${uid},ou=People,dc=example,dc=org
+objectClass: person
+objectClass: posixAccount
+objectClass: inetOrgPerson
+gecos: ${uid}
+cn: ${uid}
+sn: ${uid}
+uid: ${uid}
+homeDirectory: /home/${uid}
+uidNumber: ${idnumber}
+gidNumber: ${idnumber}
+mail: ${uid}@example.com
+userpassword: ${passwd}
+
+dn: cn=${uid},ou=Groups,dc=example,dc=org
+objectClass: posixGroup
+objectClass: groupOfMembers
+cn: ${uid}
+gidNumber: ${idnumber}
+member: cn=${uid},ou=People,dc=example,dc=org
+EOF
+    idnumber=$((idnumber + 1))
+done

--- a/ldap/install.sh
+++ b/ldap/install.sh
@@ -47,6 +47,7 @@ uidNumber: ${idnumber}
 gidNumber: ${idnumber}
 mail: ${uid}@example.com
 userpassword: ${passwd}
+loginShell: /bin/bash
 
 dn: cn=${uid},ou=Groups,dc=example,dc=org
 objectClass: posixGroup

--- a/ondemand/entrypoint.sh
+++ b/ondemand/entrypoint.sh
@@ -4,13 +4,13 @@ set -e
 if [ "$1" = "serve" ]
 then
     echo "---> Starting SSSD on ondemand ..."
-    /sbin/sssd
+    /sbin/sssd --logger=stderr -d 3 -i 2>&1 &
 
     echo "---> Starting the MUNGE Authentication service (munged) on ondemand ..."
     gosu munge /usr/sbin/munged
 
     echo "---> Starting sshd on ondemand..."
-    /usr/sbin/sshd
+    /usr/sbin/sshd -e
 
     echo "---> Starting ondemand httpd24..."
     /opt/rh/httpd24/root/usr/sbin/httpd-scl-wrapper -DFOREGROUND

--- a/ondemand/entrypoint.sh
+++ b/ondemand/entrypoint.sh
@@ -3,6 +3,9 @@ set -e
 
 if [ "$1" = "serve" ]
 then
+    echo "---> Starting SSSD on ondemand ..."
+    /sbin/sssd
+
     echo "---> Starting the MUNGE Authentication service (munged) on ondemand ..."
     gosu munge /usr/sbin/munged
 

--- a/slurm/entrypoint.sh
+++ b/slurm/entrypoint.sh
@@ -3,6 +3,9 @@ set -e
 
 if [ "$1" = "slurmdbd" ]
 then
+    echo "---> Starting SSSD ..."
+    /sbin/sssd
+
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /usr/sbin/munged
 
@@ -26,6 +29,9 @@ fi
 
 if [ "$1" = "slurmctld" ]
 then
+    echo "---> Starting SSSD ..."
+    /sbin/sssd
+
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /usr/sbin/munged
 
@@ -47,6 +53,9 @@ fi
 
 if [ "$1" = "slurmd" ]
 then
+    echo "---> Starting SSSD ..."
+    /sbin/sssd
+
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /usr/sbin/munged
 
@@ -68,6 +77,9 @@ fi
 
 if [ "$1" = "frontend" ]
 then
+    echo "---> Starting SSSD ..."
+    /sbin/sssd
+
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /usr/sbin/munged
 

--- a/slurm/entrypoint.sh
+++ b/slurm/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 if [ "$1" = "slurmdbd" ]
 then
     echo "---> Starting SSSD ..."
-    /sbin/sssd
+    /sbin/sssd --logger=stderr -d 3 -i 2>&1 &
 
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /usr/sbin/munged
@@ -22,7 +22,7 @@ then
     echo "-- Database is now active ..."
 
     echo "---> Starting sshd on the slurmdbd..."
-    /usr/sbin/sshd
+    /usr/sbin/sshd -e
 
     exec gosu slurm /usr/sbin/slurmdbd -Dv
 fi
@@ -30,7 +30,7 @@ fi
 if [ "$1" = "slurmctld" ]
 then
     echo "---> Starting SSSD ..."
-    /sbin/sssd
+    /sbin/sssd --logger=stderr -d 3 -i 2>&1 &
 
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /usr/sbin/munged
@@ -45,7 +45,7 @@ then
     echo "-- slurmdbd is now active ..."
 
     echo "---> Starting sshd on the slurmctld..."
-    /usr/sbin/sshd
+    /usr/sbin/sshd -e
 
     echo "---> Starting the Slurm Controller Daemon (slurmctld) ..."
     exec gosu slurm /usr/sbin/slurmctld -Dv
@@ -54,7 +54,7 @@ fi
 if [ "$1" = "slurmd" ]
 then
     echo "---> Starting SSSD ..."
-    /sbin/sssd
+    /sbin/sssd --logger=stderr -d 3 -i 2>&1 &
 
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /usr/sbin/munged
@@ -69,7 +69,7 @@ then
     echo "-- slurmctld is now active ..."
 
     echo "---> Starting sshd on the slurmd..."
-    /usr/sbin/sshd
+    /usr/sbin/sshd -e
 
     echo "---> Starting the Slurm Node Daemon (slurmd) ..."
     exec /usr/sbin/slurmd -Dv
@@ -78,7 +78,7 @@ fi
 if [ "$1" = "frontend" ]
 then
     echo "---> Starting SSSD ..."
-    /sbin/sssd
+    /sbin/sssd --logger=stderr -d 3 -i 2>&1 &
 
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /usr/sbin/munged
@@ -103,7 +103,7 @@ then
     fi
 
     echo "---> Starting sshd on the frontend..."
-    exec /usr/sbin/sshd -D
+    /usr/sbin/sshd -D -e
 fi
 
 exec "$@"

--- a/slurm/install.sh
+++ b/slurm/install.sh
@@ -43,8 +43,8 @@ popd
 rm -rf /tmp/slurm*
 
 log_info "Creating slurm user account.."
-groupadd -r --gid=995 slurm
-useradd -r -g slurm --uid=995 slurm
+groupadd -r --gid=1000 slurm
+useradd -r -g slurm --uid=1000 slurm
 
 log_info "Setting up slurm directories.."
 mkdir /etc/sysconfig/slurm \

--- a/xdmod/entrypoint.sh
+++ b/xdmod/entrypoint.sh
@@ -7,6 +7,9 @@ pass=ofbatgorWep0
 
 if [ "$1" = "serve" ]
 then
+    echo "---> Starting SSSD on xdmod ..."
+    /sbin/sssd
+
     echo "---> Starting the MUNGE Authentication service (munged) on xdmod ..."
     gosu munge /usr/sbin/munged
 

--- a/xdmod/entrypoint.sh
+++ b/xdmod/entrypoint.sh
@@ -8,7 +8,7 @@ pass=ofbatgorWep0
 if [ "$1" = "serve" ]
 then
     echo "---> Starting SSSD on xdmod ..."
-    /sbin/sssd
+    /sbin/sssd --logger=stderr -d 3 -i 2>&1 &
 
     echo "---> Starting the MUNGE Authentication service (munged) on xdmod ..."
     gosu munge /usr/sbin/munged
@@ -41,7 +41,7 @@ then
     fi
 
     echo "---> Starting sshd on xdmod..."
-    /usr/sbin/sshd
+    /usr/sbin/sshd -e
 
     echo "---> Starting XDMoD..."
     /usr/sbin/httpd -DFOREGROUND


### PR DESCRIPTION
This adds LDAP container that all other containers except MySQL will depend on.

The LDAP data is populated from previous data used to populate local passwd database.  Because Docker can't build files from symlinks, I had to make a copy of `base.config` that is shared between `base` and `ldap` containers.

I integrated LDAP using SSSD on all containers, this is not yet tested fully. I only tested with interactive builds of the base container.  Once OnDemand 1.8 gets its first tag we can update OnDemand to that version for LDAP integration using Dex.

Still need XDMOD and coldfront integration to the LDAP container