### PR TITLE
Add support for OnDemand bc_desktop app

### DIFF
--- a/ondemand/Dockerfile
+++ b/ondemand/Dockerfile
@@ -4,5 +4,6 @@ FROM ubccr/hpcts:slurm-${HPCTS_VERSION}
 COPY . /build
 RUN /build/install.sh && rm -rf /build
 COPY cluster-config.yml /etc/ood/config/clusters.d/hpc.yml
+COPY bc_desktop.yml /etc/ood/config/apps/bc_desktop/hpc.yml
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ondemand/bc_desktop.yml
+++ b/ondemand/bc_desktop.yml
@@ -1,0 +1,8 @@
+---
+title: "HPC Desktop"
+cluster: "hpc"
+attributes:
+  desktop: "xfce"
+  bc_account:
+      help: "You can leave this blank to use default SLURM account."
+  bc_queue: "compute"

--- a/ondemand/cluster-config.yml
+++ b/ondemand/cluster-config.yml
@@ -9,3 +9,9 @@ v2:
     cluster: "hpc"
     bin: "/usr/bin"
     conf: "/etc/slurm/slurm.conf"
+  batch_connect:
+    vnc:
+      script_wrapper: |
+        export PATH="/opt/TurboVNC/bin:$PATH"
+        export WEBSOCKIFY_CMD="/usr/bin/websockify"
+        %s

--- a/ondemand/install.sh
+++ b/ondemand/install.sh
@@ -20,6 +20,7 @@ yum install -y \
 log_info "Setting up Ondemand"
 mkdir -p /etc/ood/config/clusters.d
 mkdir -p /etc/ood/config/apps/shell
+mkdir -p /etc/ood/config/apps/bc_desktop
 echo "DEFAULT_SSHHOST=frontend" > /etc/ood/config/apps/shell/env
 
 log_info "Configuring Ondemand ood_portal.yml .."
@@ -36,6 +37,8 @@ port: 3443
 ssl:
   - 'SSLCertificateFile "/etc/pki/tls/certs/ood.crt"'
   - 'SSLCertificateKeyFile "/etc/pki/tls/private/ood.key"'
+node_uri: "/node"
+rnode_uri: "/rnode"
 oidc_scope: "openid profile email groups"
 dex:
   connectors:

--- a/slurm/install.sh
+++ b/slurm/install.sh
@@ -27,6 +27,12 @@ yum install -y \
     mariadb-devel \
     python3
 
+log_info "Installing compute packages .."
+yum install -y https://yum.osc.edu/ondemand/latest/ondemand-release-compute-latest-1-6.noarch.rpm
+yum install -y \
+  ondemand-compute
+yum groupinstall -y "Xfce"
+
 log_info "Compiling slurm version $SLURM_VERSION.."
 curl -o /tmp/slurm-${SLURM_VERSION}.tar.bz2 https://download.schedmd.com/slurm/slurm-${SLURM_VERSION}.tar.bz2
 pushd /tmp


### PR DESCRIPTION
This does not yet work 100%.  Right now the desktop app launches successfully but I'm unable to connect to the noVNC session.