### PR TITLE
Use single certificate and CA for all containers

### DIFF
--- a/coldfront/coldfront-nginx.conf
+++ b/coldfront/coldfront-nginx.conf
@@ -11,8 +11,8 @@ server {
     server_name coldfront;
 
     # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
-    ssl_certificate /srv/www/ssl/coldfront.crt;
-    ssl_certificate_key /srv/www/ssl/coldfront.key;
+    ssl_certificate /etc/pki/tls/certs/localhost.crt;
+    ssl_certificate_key /etc/pki/tls/private/localhost.key;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
     ssl_session_tickets off;

--- a/coldfront/install.sh
+++ b/coldfront/install.sh
@@ -38,10 +38,6 @@ pip install -e .
 log_info "Setting up nginx.."
 sed -i 's/ default_server;/;/' /etc/nginx/nginx.conf
 
-# Create self-signed ssl cert
-log_info "Creating self-signed ssl cert for coldfront.."
-openssl req -x509 -nodes -days 365 -subj "/C=US/ST=NY/O=HPC Tutorial/CN=coldfront" -newkey rsa:2048 -keyout /srv/www/ssl/coldfront.key -out /srv/www/ssl/coldfront.crt;
-
 chown -R coldfront.coldfront /srv/www/coldfront
 
 yum clean all

--- a/ondemand/install.sh
+++ b/ondemand/install.sh
@@ -77,7 +77,7 @@ openssl genrsa -out /etc/pki/tls/ca.key 4096
 openssl req -new -x509 -days 3650 -sha256 -key /etc/pki/tls/ca.key -extensions v3_ca -out /etc/pki/tls/ca.crt -subj "/CN=fake-ca"
 # Generate certificate request
 openssl genrsa -out /etc/pki/tls/private/ood.key 2048
-openssl req -new -sha256 -key /etc/pki/tls/private/ood.key -out /etc/pki/tls/certs/ood.csr -subj "/C=US/ST=NY/O=HPC Tutorial/CN=ondemand"
+openssl req -new -sha256 -key /etc/pki/tls/private/ood.key -out /etc/pki/tls/certs/ood.csr -subj "/C=US/ST=NY/O=HPC Tutorial/CN=localhost"
 # Config for signing cert
 cat > /etc/pki/tls/ood.ext << EOF
 authorityKeyIdentifier=keyid,issuer

--- a/xdmod/conf/httpd.conf
+++ b/xdmod/conf/httpd.conf
@@ -2,8 +2,8 @@ Listen 443 https
 <VirtualHost _default_:443>
     # Customize this section using your SSL certificate.
     SSLEngine on
-    SSLCertificateFile    /etc/pki/tls/certs/xdmod.crt
-    SSLCertificateKeyFile /etc/pki/tls/private/xdmod.key
+    SSLCertificateFile    /etc/pki/tls/certs/localhost.crt
+    SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
     <FilesMatch "\.(cgi|shtml|phtml|php)$">
         SSLOptions +StdEnvVars
     </FilesMatch>

--- a/xdmod/conf/simplesamlphp/metadata/saml20-idp-hosted.php
+++ b/xdmod/conf/simplesamlphp/metadata/saml20-idp-hosted.php
@@ -11,8 +11,8 @@
      * The private key and certificate to use when signing responses.
      * These are stored in the cert-directory.
      */
-    'privatekey' => 'private/xdmod.key',
-    'certificate' => 'certs/xdmod.crt',
+    'privatekey' => 'private/localhost.key',
+    'certificate' => 'certs/localhost.crt',
 
     /*
      * The authentication source which should be used to authenticate the

--- a/xdmod/install.sh
+++ b/xdmod/install.sh
@@ -40,10 +40,6 @@ yum install -y https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.6/x86_64/RPMS
 pip install pexpect==4.4.0
 pip install pymongo --upgrade
 
-# Create self-signed ssl cert
-log_info "Creating self-signed ssl cert for xdmod.."
-openssl req -x509 -nodes -days 365 -subj "/C=US/ST=NY/O=HPC Tutorial/CN=xdmod" -newkey rsa:2048 -keyout /etc/pki/tls/private/xdmod.key -out /etc/pki/tls/certs/xdmod.crt
-
 rm -f /etc/httpd/conf.d/ssl.conf
 
 #------------------------

--- a/xdmod/scripts/xdmod-setup-sso.sh
+++ b/xdmod/scripts/xdmod-setup-sso.sh
@@ -2,7 +2,7 @@
 
 mkdir -p /etc/xdmod/simplesamlphp/{config,metadata,cert}
 
-certString=`cat /etc/pki/tls/certs/xdmod.crt | head -n-1 | tail -n+2 | tr -d '\n'`
+certString=`cat /etc/pki/tls/certs/localhost.crt | head -n-1 | tail -n+2 | tr -d '\n'`
 
 cat << EOF > /etc/xdmod/simplesamlphp/metadata/saml20-idp-remote.php
 <?php


### PR DESCRIPTION
We have a student worker who was having certificate issues on Ubuntu and said changing the CN to `localhost` solved their issue. Without this change they were never able to even bypass the self signed cert warnings.

FWIW He also verified that exporting the container CA to Firefox got rid of all cert warnings, but not necessary to do that. This was command I had them use:

```
docker cp ondemand:/etc/pki/tls/ca.crt ./ca.crt
```