### PR TITLE
add bash completion

### DIFF
--- a/base/install.sh
+++ b/base/install.sh
@@ -34,7 +34,8 @@ yum install -y \
     openldap-clients \
     sssd \
     authconfig \
-    openssl
+    openssl \
+    bash-completion
 
 #------------------------
 # Generate ssh host keys


### PR DESCRIPTION
Makes life easier when running jobs from the command line, no more:
```
[hpcadmin@frontend ~]$ sbatch ba-bash: _get_comp_words_by_ref: command not found
-bash: _filedir: command not found
d-bash: _get_comp_words_by_ref: command not found
-bash: _filedir: command not found
```