### PR TITLE
Add back LDAP authentication to Coldfront.

### DIFF
--- a/coldfront/install.sh
+++ b/coldfront/install.sh
@@ -30,7 +30,7 @@ python3 -mvenv venv
 source venv/bin/activate
 pushd coldfront
 pip install --upgrade pip
-pip install wheel mysqlclient gunicorn python-ldap ldap3 mozilla_django_oidc
+pip install wheel mysqlclient gunicorn python-ldap ldap3 mozilla_django_oidc django_auth_ldap
 pip install -r requirements.txt
 pip install -e .
 

--- a/coldfront/local_settings.py
+++ b/coldfront/local_settings.py
@@ -154,6 +154,34 @@ LOCAL_SETTINGS_EXPORT = []
 EXTRA_AUTHENTICATION_BACKENDS += ['django_su.backends.SuBackend',]
 
 #------------------------------------------------------------------------------
+# Example config for enabling LDAP user authentication using django-auth-ldap.
+# This will enable LDAP user/password logins (provided in the LDAP container)
+#------------------------------------------------------------------------------
+import ldap
+from django_auth_ldap.config import GroupOfNamesType, LDAPSearch
+
+AUTH_LDAP_SERVER_URI = 'ldap://ldap'
+AUTH_LDAP_USER_SEARCH_BASE = 'ou=People,dc=example,dc=org'
+AUTH_LDAP_START_TLS = True
+AUTH_LDAP_BIND_DN = 'cn=admin,dc=example,dc=org'
+AUTH_LDAP_BIND_PASSWORD = 'admin'
+AUTH_LDAP_MIRROR_GROUPS = True
+AUTH_LDAP_USER_SEARCH = LDAPSearch(
+    AUTH_LDAP_USER_SEARCH_BASE, ldap.SCOPE_ONELEVEL, '(uid=%(user)s)')
+AUTH_LDAP_GROUP_SEARCH_BASE = 'ou=Groups,dc=example,dc=org'
+AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
+    AUTH_LDAP_GROUP_SEARCH_BASE, ldap.SCOPE_ONELEVEL, '(objectClass=groupOfMembers)')
+AUTH_LDAP_GROUP_TYPE = GroupOfNamesType()
+AUTH_LDAP_USER_ATTR_MAP = {
+    'username': 'uid',
+    'first_name': 'cn',
+    'last_name': 'sn',
+    'email': 'mail',
+}
+
+EXTRA_AUTHENTICATION_BACKENDS += ['django_auth_ldap.backend.LDAPBackend',]
+
+#------------------------------------------------------------------------------
 # Example config for OAuth2/OpenID Authentication. This configuration 
 # authenticates against Dex (provided in the ondemand container). 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Currently, OAuth2/OpenID authentication using Dex IdP does not support logging out. A large part of the Coldfront tutorial is showing how the various user account roles (Admin, PI, user, etc.) interact with the application. This requires easily logging in/out as different accounts. To support this we're adding back in LDAP authentication. Coldfront is now configured to support 3 backend authentication mechanisms (local login, LDAP login, and OAuth2/OpenID via Dex). This allows us to demo different user accounts while still showing how SSO integration works.