### PR TITLE
Partly setup XDMoD/OOD integration at build time

### DIFF
--- a/ondemand/cluster-config.yml
+++ b/ondemand/cluster-config.yml
@@ -15,3 +15,6 @@ v2:
         export PATH="/opt/TurboVNC/bin:$PATH"
         export WEBSOCKIFY_CMD="/usr/bin/websockify"
         %s
+  custom:
+    xdmod:
+      resource_id: 1

--- a/ondemand/motd
+++ b/ondemand/motd
@@ -20,16 +20,7 @@ Setup python environment for using Jupyter:
 
     source /usr/local/jupyter/2.1.4/bin/activate
 
-Enable XDMoD Integration
-
-    # specify XDMoD resource_id of the cluster in
-    # OnDemand's cluster config by adding this section
-    #
-    # custom:
-    #   xdmod:
-    #     resource_id: 1
-    #
-    ssh ondemand 'printf "  custom:\n    xdmod:\n      resource_id: 1\n" | sudo tee -a /etc/ood/config/clusters.d/hpc.yml'
+To enable XDMoD Integration execute on frontend via Shell app:
 
     # /etc/ood/config/nginx_stage.yml
     #
@@ -37,12 +28,21 @@ Enable XDMoD Integration
     #   OOD_XDMOD_HOST: "https://localhost:4443"
     ssh ondemand $'sudo sed -i \'s|# pun_custom_env:|pun_custom_env:\\n  OOD_XDMOD_HOST: \"https://localhost:4443\"|g\' /etc/ood/config/nginx_stage.yml'
 
-
-    # /etc/xdmod/portal_settings.ini add OnDemand to the list of domains to enable CORS
+    # modifying /etc/xdmod/portal_settings.ini for CORS already completed in these images
     #
     # domains = "https://localhost:3443"
-    ssh xdmod $'sudo sed -i \'s|domains = \"\"|domains = \"https://localhost:3443\"|g\' /etc/xdmod/portal_settings.ini'
 
-    # run ingest command to process all jobs and build reports (if this has not already been done)
+    # modifying /etc/ood/config/clusters.d/hpc.yml for XDMoD resource id already completed in these images:
+    #
+    # custom:
+    #   xdmod:
+    #     resource_id: 1
+    #
+
+Then run ingest command to process all jobs and build reports (if this has not already been done)
+
     ssh xdmod 'sudo -u xdmod /srv/xdmod/scripts/shred-ingest-aggregate-all.sh'
+
+In a production deployment you may also need to configure your identity provider to set frame-ancestors directive in the HTTP Content-Security-Policy. For example `frame-ancestors https://*.osc.edu 'self'` was required at OSC for https://ondemand.osc.edu because of its use of iFrames to facilitate single signon with XDMoD.
+
 

--- a/xdmod/install.sh
+++ b/xdmod/install.sh
@@ -45,6 +45,9 @@ yum install -y https://tas-tools-ext-01.ccr.xdmod.org/9.0.0rc2/xdmod-9.0.0-0.2.r
                https://tas-tools-ext-01.ccr.xdmod.org/9.0.0rc2/xdmod-supremm-9.0.0-0.2.rc2.el7.noarch.rpm \
                https://github.com/ubccr/supremm/releases/download/1.4.0rc01/supremm-1.4.0-rc01.el7.x86_64.rpm
 
+# modify portal_settings.ini to enable CORS for OnDemand
+sed -i 's%domains = ""%domains = "https://localhost:3443"%g' /etc/xdmod/portal_settings.ini
+
 #------------------------
 # phantomjs is used by Open XDMoD for chart image export and for the
 # report generator.


### PR DESCRIPTION
the trailing lines at the end of the motd is intentional, because it
appears whenever you login in via the shell to the ondemand host

This keeps manual step required to enable XDMoD integration in OnDemand, since there isn't value in participants executing shell commands do all the steps.