### PR TITLE
Move the editing of the configuration files into the correct place.

### DIFF
--- a/xdmod/entrypoint.sh
+++ b/xdmod/entrypoint.sh
@@ -43,6 +43,17 @@ then
         echo "---> Open XDMoD Setup: finish"
         expect /srv/xdmod/scripts/xdmod-setup-finish.tcl | col -b
 
+        #------------------------
+        # The xdmod-setup interactive script includes menu items for all of the
+        # common basic Open XDMoD configuration.  The
+        # /etc/xdmod/portal_settings.ini file can always be manually edited for
+        # site-specific configuration For the demo we enable the CORS setting
+        # to allow the Open XDMoD server to process requests from within
+        # OnDemand. In a production system this should be set to the
+        # appropriate address of the OnDemand webserver.
+        #------------------------
+        sed -i 's%domains = ""%domains = "https://localhost:3443"%g' /etc/xdmod/portal_settings.ini
+
         echo "Open XDMoD Import: Hierarchy"
         sudo -u xdmod xdmod-import-csv -t hierarchy -i /srv/xdmod/hierarchy.csv
 

--- a/xdmod/install.sh
+++ b/xdmod/install.sh
@@ -45,9 +45,6 @@ yum install -y https://tas-tools-ext-01.ccr.xdmod.org/9.0.0rc3/xdmod-9.0.0-0.3.r
                https://tas-tools-ext-01.ccr.xdmod.org/9.0.0rc3/xdmod-supremm-9.0.0-0.3.rc3.el7.noarch.rpm \
                https://github.com/ubccr/supremm/releases/download/1.4.0rc01/supremm-1.4.0-rc01.el7.x86_64.rpm
 
-# modify portal_settings.ini to enable CORS for OnDemand
-sed -i 's%domains = ""%domains = "https://localhost:3443"%g' /etc/xdmod/portal_settings.ini
-
 #------------------------
 # phantomjs is used by Open XDMoD for chart image export and for the
 # report generator.


### PR DESCRIPTION
The scripts are structured to split out different categories of setup. The
install script is split into two sections: install of packages and
dependencies and update of mandatory O/S configuration.
We don't want the install script to contain tutorial-specifc configuration since we
discuss this at a different point.

Instead the tutorial-specific configuration happens when we discuss the
entry_point script.