### PR TITLE
Enable scl for hpcadmin in bash_profile

### DIFF
--- a/ondemand/initializers/dashboard.rb
+++ b/ondemand/initializers/dashboard.rb
@@ -5,3 +5,17 @@ dest = "#{ENV['HOME']}/jupyter_notebook_data"
 unless Dir.exists?(dest)
   FileUtils.copy_entry src, dest
 end
+
+load_scl = <<EOF
+
+if [[ ${HOSTNAME%%.*} == ondemand ]]
+then
+  source scl_source enable ondemand
+fi
+
+EOF
+
+profile = File.join(Dir.home, ".bash_profile")
+if File.file?(profile) && File.readable?(profile) && File.writable?(profile) && ! File.read(profile).include?("source scl_source enable ondemand")
+  File.open(profile, "a") {|f| f.write(load_scl) }
+end


### PR DESCRIPTION
I wasn't sure where to do this. If you have a suggestion let me know.

The block of code in this initializer executes every time the dashboard app of OnDemand starts up. It adds the block to the ~/.bash_profile if that file can be read and written to and doesn't already load scl when ssh-ing to the ondemand host.