### PR TITLE
Pip version for Python 3.6

### DIFF
--- a/slurm/install.sh
+++ b/slurm/install.sh
@@ -89,7 +89,7 @@ sed -i 's#^LOCALHOSTNAME.*$#LOCALHOSTNAME   y   n   "/home/pcp/$(date +%Y)/$(dat
 log_info "Installing Jupyter.."
 python3 -m venv --without-pip --prompt jupyter/2.1.4 /usr/local/jupyter/2.1.4
 source /usr/local/jupyter/2.1.4/bin/activate
-curl https://bootstrap.pypa.io/get-pip.py | python
+curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | python
 pip install jupyterlab==2.1.4 jupyter-console qtconsole ipywidgets plotly==4.8.2 pandas scikit-learn numpy
 deactivate
 


### PR DESCRIPTION
Seems need a specific version of Pip for Python 3.6 - install currently fails due to pip install complaining about Python version.  Currently see:

```
 Installing Jupyter..

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2596k  100 2596k    0     0  7281k      0 --:--:-- --:--:-- --:--:-- 7293k
ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.
failed

The command '/bin/sh -c /build/install.sh && rm -rf /build' returned a non-zero code: 1
ERROR: Service 'slurmdbd' failed to build : Build failed

 Coldfront URL: https://localhost:2443
```