### PR TITLE
build ood components from source code for aarch64

### DIFF
--- a/ondemand/entrypoint.sh
+++ b/ondemand/entrypoint.sh
@@ -23,6 +23,9 @@ then
     echo "---> Starting sshd on ondemand..."
     /usr/sbin/sshd -e
 
+    echo "---> Running update ood portal..."
+    /opt/ood/ood-portal-generator/sbin/update_ood_portal
+
     echo "---> Starting ondemand-dex..."
     gosu ondemand-dex /usr/sbin/ondemand-dex serve /etc/ood/dex/config.yaml &
 

--- a/ondemand/install.sh
+++ b/ondemand/install.sh
@@ -123,7 +123,7 @@ install_os_deps() {
         nodejs sqlite sqlite-devel nmap-ncat httpd httpd-devel mod_ssl \
         libcurl-devel autoconf openssl-devel jansson-devel libxml2-devel \
         libxslt-devel gd-devel
-  gem install rake dotenv
+  gem install rake dotenv bcrypt
 }
 
 build_ood_src() {
@@ -147,8 +147,10 @@ build_ood_src() {
   make && make install
 
   cd $BUILD_DIR
-  git clone https://github.com/OSC/ondemand.git
-  cd ondemand
+  OOD_VERSION='2.0.27'
+  wget "https://github.com/OSC/ondemand/archive/refs/tags/v$OOD_VERSION.tar.gz"
+  tar -xf "v$OOD_VERSION.tar.gz"
+  cd ondemand-$OOD_VERSION
   bundle config --local path ~/vendor/bundle
   bundle install
   rake build -mj$(nproc)


### PR DESCRIPTION
Fixes #116 by building ood components from source code for aarch64.

I tested it as much as I could (by hardcoding `ARCHTYPE`) but ran into #119. Which is to say it boots up and seems to work as well as Slurm will let it.