### PR TITLE
Mount slurm state directories as volumes.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
     volumes:
       - etc_munge:/etc/munge
       - etc_slurm:/etc/slurm
+      - slurmdbd_state:/var/lib/slurmd
     expose:
       - "22"
       - "6819"
@@ -88,6 +89,7 @@ services:
       - etc_munge:/etc/munge
       - etc_slurm:/etc/slurm
       - home:/home
+      - slurmctld_state:/var/lib/slurmd
     expose:
       - "22"
       - "6817"
@@ -107,6 +109,7 @@ services:
       - etc_munge:/etc/munge
       - etc_slurm:/etc/slurm
       - home:/home
+      - cpn01_slurmd_state:/var/lib/slurmd
     expose:
       - "22"
       - "6818"
@@ -126,6 +129,7 @@ services:
       - etc_munge:/etc/munge
       - etc_slurm:/etc/slurm
       - home:/home
+      - cpn02_slurmd_state:/var/lib/slurmd
     expose:
       - "22"
       - "6818"
@@ -229,6 +233,10 @@ volumes:
   etc_slurm:
   home:
   var_lib_mysql:
+  cpn01_slurmd_state:
+  cpn02_slurmd_state:
+  slurmctld_state:
+  slurmdbd_state:
   data_db:
   srv_www:
 


### PR DESCRIPTION
Fixes #119. After stopping/starting containers the `hpcadmin` user could no longer submit jobs without specifying a slurm account, even though the slurm association had a DefaultAccount set for that user. This appears to be due to the slurm state directories not persisting after a restart. This PR adds volumes for slurmd, slurmctld, and slurmdbd for the slurm state directory.