### PR TITLE
run nginx clean on start for safe restart

### DIFF
--- a/ondemand/entrypoint.sh
+++ b/ondemand/entrypoint.sh
@@ -9,6 +9,9 @@ then
         sleep 2
     done
 
+    echo "---> Cleaning NGINX ..."
+    /opt/ood/nginx_stage/sbin/nginx_stage nginx_clean
+
     echo "---> Populating /etc/ssh/ssh_known_hosts from frontend for ondemand..."
     /usr/bin/ssh-keyscan frontend >> /etc/ssh/ssh_known_hosts
 


### PR DESCRIPTION
Fixes #134 by running `nginx_stage` to clean the PUNs that may be left over from the last startup.