### PR TITLE
Adding a new volume for xdmods etc directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,7 @@ services:
     networks:
       - compute
     volumes:
+      - etc_xdmod:/etc/xdmod
       - etc_munge:/etc/munge
       - etc_slurm:/etc/slurm
       - home:/home
@@ -229,6 +230,7 @@ services:
       - frontend
 
 volumes:
+  etc_xdmod:
   etc_munge:
   etc_slurm:
   home:


### PR DESCRIPTION
This fixes: https://github.com/ubccr/hpc-toolset-tutorial/issues/135 

When doing a `docker-compose down` XDMoD's etc directory would be reset to
container default, adding a new volume ensures that this persists between
docker-compose downs and ups.