### PR TITLE
Revert incorrect rpm install from #153

### DIFF
--- a/xdmod/install.sh
+++ b/xdmod/install.sh
@@ -45,8 +45,7 @@ dnf install -y \
 #------------------------
 dnf install -y https://github.com/ubccr/xdmod/releases/download/v10.0.2-2-el8/xdmod-10.0.2-2.0.el8.noarch.rpm \
                https://github.com/ubccr/xdmod-ondemand/releases/download/v10.0.0/xdmod-ondemand-10.0.0-1.0.beta1.el8.noarch.rpm \
-               https://github.com/ubccr/xdmod/releases/download/v10.0.0-beta4-el8/xdmod-supremm-10.0.0-1.4.beta4.el8.noarch.rpm \
-               https://github.com/ubccr/xdmod-appkernels/releases/download/v10.0.0/xdmod-appkernels-10.0.0-1.0.beta1.el8.noarch.rpm
+               https://github.com/ubccr/xdmod/releases/download/v10.0.0-beta4-el8/xdmod-supremm-10.0.0-1.4.beta4.el8.noarch.rpm
 
 # supremm rpm has broken deps so we force install the rpm and install the deps via pip
 rpm --nodeps -ivh https://github.com/ubccr/supremm/releases/download/2.0.0-beta3/supremm-2.0.0-1.0_beta3.el8."$ARCHTYPE".rpm

--- a/xdmod/scripts/xdmod-setup-ondemand.tcl
+++ b/xdmod/scripts/xdmod-setup-ondemand.tcl
@@ -36,7 +36,7 @@ confirmFileWrite yes
 enterToContinue
 
 # Setup the OnDemand database
-selectMenuOption 11
+selectMenuOption 10
 
 selectMenuOption d
 

--- a/xdmod/scripts/xdmod-setup-supremm.tcl
+++ b/xdmod/scripts/xdmod-setup-supremm.tcl
@@ -19,7 +19,7 @@ source [file join [file dirname [info script]] helper-functions.tcl]
 set timeout 240
 spawn "xdmod-setup"
 
-selectMenuOption 10
+selectMenuOption 9
 
 selectMenuOption d
 answerQuestionAlt {DB Admin Username:} root


### PR DESCRIPTION
The pull request #153 added the appkernels RPM to the build. This was never in the original tutorial and cannot be simply added without also adding the configuration files, installing the AKRR and also updating the setup script.

Adding the RPM without the corresponding other pacakges and configuration results in a broken XDMoD portal.