### PR TITLE
Fix permissions for portal settings files

### DIFF
--- a/xdmod/setup.sh
+++ b/xdmod/setup.sh
@@ -4,6 +4,9 @@ echo "Import configuration files"
 if [ -f "/xdmod/conf/xdmod_etc.tar.gz" ]; then
   tar -xvzf /xdmod/conf/xdmod_etc.tar.gz --strip-components 1 -C /etc
   chown -R root:apache /etc/xdmod
+  chown    apache:xdmod /etc/xdmod/portal_settings.ini
+  chown    apache:xdmod /etc/xdmod/portal_settings.d/ondemand.ini
+  chown    apache:xdmod /etc/xdmod/portal_settings.d/supremm.ini
 fi
 
 echo "Setting Default Timeframe"


### PR DESCRIPTION
Fixes permission issues due to the portal_settings.ini , ondemand.ini, and supremm.ini files having owner and group set to `root:apache` instead of `apache:xdmod` which is required to shred, ingest and aggregate data.