### PR TITLE
OOD needs to use release_3.0 branch

### DIFF
--- a/ondemand/README.md
+++ b/ondemand/README.md
@@ -328,6 +328,7 @@ mkdir -p ~/ondemand/dev
 cd ~/ondemand/dev
 ln -s ../../ondemand-src-full/apps/dashboard/ dashboard
 cd dashboard
+git checkout release_3.0
 bin/bundle config --local path vendor/bundle
 bin/setup
 ```


### PR DESCRIPTION
OOD needs to use `release_3.0` branch for the dashboard setup because 3.0 is what's installed in the container.