### PR TITLE
Adding disable-skip-name-resolve to mysql

### DIFF
--- a/database/skip-name-resolve.cnf
+++ b/database/skip-name-resolve.cnf
@@ -1,0 +1,2 @@
+[mariadb]
+disable-skip-name-resolve=1


### PR DESCRIPTION
The changes in this PR arose from a desire to be able to choose between having a fully configured & populated XDMoD database & a fully configured but _**empty**_ XDMoD database. The method of having a fully configured by empty database, from investigation, seemed to be: remove / rename the `database/xdmod.dump` file and the included bash scripts would take care of the rest. Upon testing it was found that the scripts that handle the setup of users and databases for XDMoD, when the dump is not present, were relying on MariaDB allowing / using hostname's for database users. This conflicted with a new(-ish) MariaDB configuration `skip-name-resolve` being enabled, which means that all database user `hosts` would need to be IP Addresses not hostnames, this was causing said scripts to error out due to authentication errors. 

This PR simply disables the `skip-name-resolve` configuration option so that we can use hostnames as user hosts again.

