### PR TITLE
 Fix expect script not dealing with a new xdmod version check & update version

### DIFF
--- a/xdmod/install.sh
+++ b/xdmod/install.sh
@@ -10,6 +10,7 @@ log_info() {
 log_info "Installing required packages for xdmod.."
 
 ARCHTYPE=`uname -m`
+XDMOD_VERSION="11.0.1-1"
 
 #------------------------
 # For the purpose of the tutorial we install some extra packages that
@@ -46,9 +47,9 @@ dnf install -y \
 # be installed in the same container.  In a production deployment they may be installed
 # on separate hosts.
 #------------------------
-dnf install -y https://github.com/ubccr/xdmod/releases/download/v11.0.0-1.0/xdmod-11.0.0-1.0.el8.noarch.rpm \
-               https://github.com/ubccr/xdmod-ondemand/releases/download/v11.0.0-1.0/xdmod-ondemand-11.0.0-1.0.el8.noarch.rpm \
-               https://github.com/ubccr/xdmod-supremm/releases/download/v11.0.0-1.0/xdmod-supremm-11.0.0-1.0.el8.noarch.rpm \
+dnf install -y https://github.com/ubccr/xdmod/releases/download/v${XDMOD_VERSION}/xdmod-${XDMOD_VERSION}.el8.noarch.rpm \
+               https://github.com/ubccr/xdmod-ondemand/releases/download/v${XDMOD_VERSION}/xdmod-ondemand-${XDMOD_VERSION}.el8.noarch.rpm \
+               https://github.com/ubccr/xdmod-supremm/releases/download/v${XDMOD_VERSION}/xdmod-supremm-${XDMOD_VERSION}.el8.noarch.rpm \
                https://github.com/ubccr/supremm/releases/download/2.0.0/supremm-2.0.0-1.el8.${ARCHTYPE}.rpm
 
 #------------------------

--- a/xdmod/scripts/helper-functions.tcl
+++ b/xdmod/scripts/helper-functions.tcl
@@ -62,3 +62,14 @@ proc confirmDropDb { response } {
 	}
 	send $response\n
 }
+
+proc ignoreNewVersion {} {
+    expect {
+        "Do you want to continue" {
+        send "yes"
+        exp_continue
+        }
+    "Open XDMoD Setup" {
+        }
+    }
+}

--- a/xdmod/scripts/xdmod-setup-finish.tcl
+++ b/xdmod/scripts/xdmod-setup-finish.tcl
@@ -14,6 +14,7 @@ source [file join [file dirname [info script]] helper-functions.tcl]
 set timeout 240
 spawn "xdmod-setup"
 
+ignoreNewVersion
 selectMenuOption 5
 provideInput {Username:} admin
 providePassword {Password:} admin

--- a/xdmod/scripts/xdmod-setup-ondemand.tcl
+++ b/xdmod/scripts/xdmod-setup-ondemand.tcl
@@ -19,6 +19,8 @@ source [file join [file dirname [info script]] helper-functions.tcl]
 set timeout 240
 spawn "xdmod-setup"
 
+
+ignoreNewVersion
 # Add an OnDemand resource
 selectMenuOption 4
 

--- a/xdmod/scripts/xdmod-setup-start.tcl
+++ b/xdmod/scripts/xdmod-setup-start.tcl
@@ -14,6 +14,7 @@ source [file join [file dirname [info script]] helper-functions.tcl]
 set timeout 240
 spawn "xdmod-setup"
 
+ignoreNewVersion
 selectMenuOption 1
 answerQuestion {Site Address} https://localhost:4443/
 provideInput {Email Address:} ccr-xdmod-help@buffalo.edu

--- a/xdmod/scripts/xdmod-setup-supremm.tcl
+++ b/xdmod/scripts/xdmod-setup-supremm.tcl
@@ -19,6 +19,7 @@ source [file join [file dirname [info script]] helper-functions.tcl]
 set timeout 240
 spawn "xdmod-setup"
 
+ignoreNewVersion
 selectMenuOption 9
 
 selectMenuOption d


### PR DESCRIPTION
If a new version of xdmod exists, the xdmod-setup script informs
of this, and expects a yes/no answer to continue. This stalls any
expect script spawning the xdmod-setup script - so fix it.

Also update xdmod version to the latest, using a variable to hold the value